### PR TITLE
refactor: clean up setup script and update test configurations

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -38,10 +38,6 @@ echo "Building project in debug mode..."
 cargo build
 
 echo ""
-echo "=== Running tests to verify setup ==="
-cargo test
-
-echo ""
 echo "=== Development environment setup complete! ==="
 echo ""
 echo "Available development commands:"

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,7 +142,7 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
-    use crate::universal_rule::{UniversalRule, UniversalRuleFrontmatter}; // For creating test rule files
+    use crate::universal_rule::UniversalRuleFrontmatter; // For creating test rule files
 
     /// Helper function to set up a temporary rules directory with specified rule files for testing.
     ///
@@ -189,6 +189,7 @@ mod tests {
             rules_dir: rules_path,
             agent: AgentName::Cursor,
             output_dir: output_path.clone(),
+            no_gitignore: false,
         };
         
         // Simulate running main's logic for Cursor
@@ -236,6 +237,7 @@ mod tests {
             rules_dir: rules_path,
             agent: AgentName::Windsurf,
             output_dir: output_path.clone(),
+            no_gitignore: false,
         };
 
         let rules = discover_and_parse_rules(&cli.rules_dir)?;
@@ -267,6 +269,7 @@ mod tests {
             rules_dir: rules_path,
             agent: AgentName::Claude,
             output_dir: output_path.clone(),
+            no_gitignore: false,
         };
         
         let rules = discover_and_parse_rules(&cli.rules_dir)?;

--- a/src/rule_parser.rs
+++ b/src/rule_parser.rs
@@ -1,7 +1,7 @@
 // src/rule_parser.rs
 
 use std::fs;
-use std::path::{Path, PathBuf}; // PathBuf is not used directly here, but often useful with Path
+use std::path::Path; // PathBuf is not used directly here, but often useful with Path
 use walkdir::WalkDir;
 use serde_yaml;
 use anyhow::{Context, Result, anyhow};

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 use std::fs::{self, File};
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command; // Used to get the binary path
 
 use assert_cmd::prelude::*; // Add methods on commands


### PR DESCRIPTION
Removed the test execution step from the setup script to streamline the setup process. Updated test configurations in `main.rs` to include the `no_gitignore` option for multiple agents. Adjusted imports in `rule_parser.rs` and `integration_tests.rs` for consistency and clarity.